### PR TITLE
Allow background multiimage to use fanart1, fanart2 ... from scrapers

### DIFF
--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -12,6 +12,7 @@
 	<include file="Includes_MediaFlags.xml" />
 	<include file="Includes_MediaFlags2.xml" />
 	<include file="Includes_Animations.xml" />
+	<include file="Includes_ExtraFanart.xml" />
 	<include file="Viewtype_Common.xml" />
 	<include file="Viewtype_Banner.xml" />			<!-- 511 -->
 	<include file="Viewtype_BannerPoster.xml" />		<!-- 510 -->
@@ -66,17 +67,44 @@
 		<control type="image">
 			<include>Global_Background_Fanart_Common</include>
 			<texture background="true" diffuse="FanartDiffuse.png">$VAR[GlobalFanart]</texture>
-			<visible>String.IsEmpty(Control.GetLabel(6999)) + [[[Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)] + !Skin.HasSetting(HideVideoFanart)] | [[Container.Content(artists) | Container.Content(albums) | Container.Content(songs)] + !Skin.HasSetting(HideMusicFanart)] | [Window.IsActive(pictures) + !Skin.HasSetting(HidePictureFanart)] | Container.Content(addons)]</visible>
+			<visible>!Skin.HasSetting(SkinHelper.EnableExtraFanart) 
+				| [Skin.HasSetting(SkinHelper.EnableExtraFanart) + !Skin.HasSetting(SkinHelper.UseFanart1) + String.IsEmpty(Control.GetLabel(6999))]
+				| [Skin.HasSetting(SkinHelper.EnableExtraFanart) + Skin.HasSetting(SkinHelper.UseFanart1) + String.IsEmpty(Control.GetLabel(69999))]
+			</visible>
+			<visible>[[[Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(musicvideos)] + !Skin.HasSetting(HideVideoFanart)] | [[Container.Content(artists) | Container.Content(albums) | Container.Content(songs)] + !Skin.HasSetting(HideMusicFanart)] | [Window.IsActive(pictures) + !Skin.HasSetting(HidePictureFanart)] | Container.Content(addons)]</visible>
 		</control>
-		<!-- Extra Fanart -->
+		<!-- Extra Fanart from extrafanart directory-->
 		<control type="multiimage" id="6999">
 			<include>Global_Background_Fanart_Common</include>
 			<imagepath background="true" diffuse="FanartDiffuse.png">$VAR[GlobalExtraFanart]</imagepath>
 			<timeperimage>5000</timeperimage>
 			<randomize>true</randomize>
 			<loop>yes</loop>
-			<visible>Skin.HasSetting(SkinHelper.EnableExtraFanart) + [[[Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)] + !Skin.HasSetting(HideVideoFanart)] | [[Container.Content(artists) | Container.Content(albums) | Container.Content(songs)] + !Skin.HasSetting(HideMusicFanart)] | [Window.IsActive(pictures) + !Skin.HasSetting(HidePictureFanart)]]</visible>
+			<visible>Skin.HasSetting(SkinHelper.EnableExtraFanart) + !Skin.HasSetting(SkinHelper.UseFanart1)</visible>
+			<visible>[[[Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(musicvideos)] + !Skin.HasSetting(HideVideoFanart)] | [[Container.Content(artists) | Container.Content(albums) | Container.Content(songs)] + !Skin.HasSetting(HideMusicFanart)] | [Window.IsActive(pictures) + !Skin.HasSetting(HidePictureFanart)]]</visible>
 		</control>
+		<!-- Extra Fanart from fanart1, fanart2, ... -->
+		<control type="fadelabel" id="69998">
+			<left>-100</left>
+			<top>-100</top>
+			<width>0</width>
+			<height>0</height>
+			<font>METF_MediaDetailsSmall</font>
+			<scrollspeed>200</scrollspeed>
+			<scrollout>false</scrollout>
+			<scroll>true</scroll>
+			<randomize>true</randomize>
+	        <include>ExtraFanartItems</include>
+	 	</control>
+		<control type="multiimage" id="69999">
+			<include>Dimensions_Fullscreen</include>
+			<imagepath background="true" diffuse="FanartDiffuse.png">$INFO[Control.GetLabel(69998)]</imagepath>
+			<timeperimage>12000</timeperimage>
+			<fadetime>3000</fadetime>
+			<resetonlabelchange>true</resetonlabelchange>
+			<visible>Skin.HasSetting(SkinHelper.EnableExtraFanart) + Skin.HasSetting(SkinHelper.UseFanart1)</visible>
+			<visible>[[[Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(musicvideos)] + !Skin.HasSetting(HideVideoFanart)] | [[Container.Content(artists) | Container.Content(albums) | Container.Content(songs)] + !Skin.HasSetting(HideMusicFanart)] | [Window.IsActive(pictures) + !Skin.HasSetting(HidePictureFanart)]]</visible>
+		</control>	
 	</include>
 	<include name="Global_ContextFilter">
 		<control type="image">

--- a/720p/Includes_ExtraFanart.xml
+++ b/720p/Includes_ExtraFanart.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<includes>
+	<include name="ExtraFanartItems">
+	        <info>ListItem.Art(fanart)</info>
+			<info>ListItem.Art(fanart1)</info>
+			<info>ListItem.Art(fanart2)</info>
+			<info>ListItem.Art(fanart3)</info>
+			<info>ListItem.Art(fanart4)</info>
+			<info>ListItem.Art(fanart5)</info>
+			<info>ListItem.Art(fanart6)</info>
+			<info>ListItem.Art(fanart7)</info>
+			<info>ListItem.Art(fanart8)</info>
+			<info>ListItem.Art(fanart9)</info>
+			<!-- tvshow.fanart are filled with the series fanart when navigating season and episode lists -->
+			<info>ListItem.Art(tvshow.fanart)</info>
+			<info>ListItem.Art(tvshow.fanart1)</info>
+			<info>ListItem.Art(tvshow.fanart2)</info>
+			<info>ListItem.Art(tvshow.fanart3)</info>
+			<info>ListItem.Art(tvshow.fanart4)</info>
+			<info>ListItem.Art(tvshow.fanart5)</info>
+			<info>ListItem.Art(tvshow.fanart6)</info>
+			<info>ListItem.Art(tvshow.fanart7)</info>
+			<info>ListItem.Art(tvshow.fanart8)</info>
+			<info>ListItem.Art(tvshow.fanart9)</info>
+			<!-- Container.ListItem.Art() are filled based on the focused ListItem in the **focused container** in Leia -->
+			<info>Container.ListItem.Art(fanart)</info>
+			<info>Container.ListItem.Art(fanart1)</info>
+			<info>Container.ListItem.Art(fanart2)</info>
+			<info>Container.ListItem.Art(fanart3)</info>
+			<info>Container.ListItem.Art(fanart4)</info>
+			<info>Container.ListItem.Art(fanart5)</info>
+			<info>Container.ListItem.Art(fanart6)</info>
+			<info>Container.ListItem.Art(fanart7)</info>
+			<info>Container.ListItem.Art(fanart8)</info>
+			<info>Container.ListItem.Art(fanart9)</info>
+			<info>Container.ListItem.Art(tvshow.fanart)</info>
+			<info>Container.ListItem.Art(tvshow.fanart1)</info>
+			<info>Container.ListItem.Art(tvshow.fanart2)</info>
+			<info>Container.ListItem.Art(tvshow.fanart3)</info>
+			<info>Container.ListItem.Art(tvshow.fanart4)</info>
+			<info>Container.ListItem.Art(tvshow.fanart5)</info>
+			<info>Container.ListItem.Art(tvshow.fanart6)</info>
+			<info>Container.ListItem.Art(tvshow.fanart7)</info>
+			<info>Container.ListItem.Art(tvshow.fanart8)</info>
+			<info>Container.ListItem.Art(tvshow.fanart9)</info>	
+	</include>
+</includes>

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -654,6 +654,13 @@
 						<onclick>Skin.ToggleSetting(SkinHelper.EnableExtraFanart)</onclick>
 						<selected>Skin.HasSetting(SkinHelper.EnableExtraFanart)</selected>
 					</control>
+					<control type="radiobutton" id="7081">
+						<include>SettingsLabel</include>
+						<label>    $LOCALIZE[33055] fanart1, fanart2, ...</label>
+						<onclick>Skin.ToggleSetting(SkinHelper.UseFanart1)</onclick>
+						<selected>Skin.HasSetting(SkinHelper.UseFanart1)</selected>
+						<visible>Skin.HasSetting(SkinHelper.EnableExtraFanart)</visible>
+					</control>
 					<control type="image" id="709">
 						<include>Settings_Line</include>
 					</control>


### PR DESCRIPTION
Modify SkinSettings.xml to add switch that enables using fanart1, fanart2, ... instead of extrafanart directory.
Modify Includes.xml to add new multiimage control based on fanart1, fanart2, ... from scrapers. Allow background fanart  on musicvideos. Make sure visibilty fallback works correctly when multiimages have no content.
Add file Includes_ExtraFanart.xml to hold what images from the scrapers should be used.